### PR TITLE
core: Always initialize extra

### DIFF
--- a/core/oidc.go
+++ b/core/oidc.go
@@ -352,6 +352,7 @@ func (t *TokenRequest) PrefillIDToken(iss, sub string, expires time.Time) IDToke
 		IssuedAt: NewUnixTime(t.now()),
 		AuthTime: newUnixTimeProto(t.authTime),
 		Nonce:    t.authReq.Nonce,
+		Extra:    map[string]interface{}{},
 	}
 }
 

--- a/core/oidc_test.go
+++ b/core/oidc_test.go
@@ -289,6 +289,7 @@ func TestIDTokenPrefill(t *testing.T) {
 				ACR:      "acr",
 				Nonce:    "nonce",
 				AMR:      "amr",
+				Extra:    map[string]interface{}{},
 			},
 		},
 	} {


### PR DESCRIPTION
Go handles empty maps poorly, so make prefill initialize it. It will be omitted
from the JSON if nothing is added to it.