### PR TITLE
core: Make session storage easier to implement

### DIFF
--- a/core/oidc.go
+++ b/core/oidc.go
@@ -35,9 +35,9 @@ type Session interface {
 // lifecycle.
 type SessionManager interface {
 	// GetSession should return the current session state for the given session
-	// ID. If the session does not exist, it should return a nil session and no
-	// error.
-	GetSession(ctx context.Context, sessionID string) (Session, error)
+	// ID. It should be deserialized/written in to into. If the session does not
+	// exist, found should be false with no error.
+	GetSession(ctx context.Context, sessionID string, into Session) (found bool, err error)
 	// PutSession should persist the new state of the session
 	PutSession(context.Context, Session) error
 	// DeleteSession should remove the corresponding session.
@@ -705,16 +705,14 @@ func strsContains(strs []string, s string) bool {
 }
 
 func getSession(ctx context.Context, sm SessionManager, sessionID string) (*corev1beta1.Session, error) {
-	s, err := sm.GetSession(ctx, sessionID)
+	sess := &corev1beta1.Session{}
+
+	found, err := sm.GetSession(ctx, sessionID, sess)
 	if err != nil {
 		return nil, err
 	}
-	if s == nil {
+	if !found {
 		return nil, nil
 	}
-	cs, ok := s.(*corev1beta1.Session)
-	if !ok {
-		return nil, fmt.Errorf("Session implementation is of unknown type: %T", s)
-	}
-	return cs, nil
+	return sess, nil
 }


### PR DESCRIPTION
We previously relied on the session manager to return the saved item as an
interface. In practice this is hard to implement, as the implementation has no
awareness of the concrete type that should be serialized/deserialized

Fix this by moving to an "into" method, ala proto/JSON marshaling. This allows
the code which is aware of the concrete type to instantiate it, and delegates
just the deserialization to the implementation.

This will make versioning slightly harder, as it's unclear what concrete type
we should be creating if there are multiple possibilities. I think this is OK
for now, in future we could do a two-pass setup to try and inspect a version
field (which we have reserved in the proto definition), or start using a
higher-level message that is just metadata and a google.protobuf.Any.