### PR TITLE
core: Pass io.Writer rather than json.Encoder for Userinfo

### DIFF
--- a/core/oidc.go
+++ b/core/oidc.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -614,10 +615,10 @@ type UserinfoRequest struct {
 // Userinfo can handle a request to the userinfo endpoint. If the request is not
 // valid, an error will be returned. Otherwise handler will be invoked with
 // information about the requestor passed in. This handler should write the
-// response data to the passed JSON encoder.
+// appropriate response data in JSON format to the passed writer.
 //
 // https://openid.net/specs/openid-connect-core-1_0.html#UserInfoResponse
-func (o *OIDC) Userinfo(w http.ResponseWriter, req *http.Request, handler func(w *json.Encoder, uireq *UserinfoRequest) error) error {
+func (o *OIDC) Userinfo(w http.ResponseWriter, req *http.Request, handler func(w io.Writer, uireq *UserinfoRequest) error) error {
 	authSp := strings.SplitN(req.Header.Get("authorization"), " ", 2)
 	if !strings.EqualFold(authSp[0], "bearer") || len(authSp) != 2 {
 		be := &bearerError{} // no content, just request auth
@@ -675,9 +676,8 @@ func (o *OIDC) Userinfo(w http.ResponseWriter, req *http.Request, handler func(w
 	uireq := &UserinfoRequest{
 		SessionID: uaccess.SessionId,
 	}
-	jenc := json.NewEncoder(w)
 
-	if err := handler(jenc, uireq); err != nil {
+	if err := handler(w, uireq); err != nil {
 		herr := &httpError{Code: http.StatusInternalServerError, Cause: err, CauseMsg: "error in user handler"}
 		_ = writeError(w, req, herr)
 		return herr

--- a/core/oidc_test.go
+++ b/core/oidc_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"math"
 	"net/http/httptest"
 	"net/url"
@@ -756,12 +757,12 @@ func TestFetchRefreshSession(t *testing.T) {
 }
 
 func TestUserinfo(t *testing.T) {
-	echoHandler := func(w *json.Encoder, uireq *UserinfoRequest) error {
+	echoHandler := func(w io.Writer, uireq *UserinfoRequest) error {
 		o := map[string]interface{}{
 			"gotsess": uireq.SessionID,
 		}
 
-		if err := w.Encode(o); err != nil {
+		if err := json.NewEncoder(w).Encode(o); err != nil {
 			t.Fatal(err)
 		}
 
@@ -773,7 +774,7 @@ func TestUserinfo(t *testing.T) {
 		// Setup should return both a session to be persisted, and an access
 		// token
 		Setup   func(t *testing.T) (sess *corev1beta1.Session, accessToken string)
-		Handler func(w *json.Encoder, uireq *UserinfoRequest) error
+		Handler func(w io.Writer, uireq *UserinfoRequest) error
 		// WantErr signifies that we expect an error
 		WantErr bool
 		// WantJSON is what we want the endpoint to return


### PR DESCRIPTION
The implementation might want to use custom json marshaling (e.g jsonpb), so
pass a generic writer instead.