### PR TITLE
Unescape basic auth creds

### DIFF
--- a/core/oauth2_token.go
+++ b/core/oauth2_token.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 )
@@ -42,8 +43,16 @@ func parseTokenRequest(req *http.Request) (*tokenRequest, error) {
 	// https://tools.ietf.org/html/rfc6749#section-2.3
 	cid, cs, isBasic := req.BasicAuth()
 	if isBasic {
-		tr.ClientID = cid
-		tr.ClientSecret = cs
+		var err error
+		tr.ClientID, err = url.QueryUnescape(cid)
+		if err != nil {
+			return nil, &tokenError{Code: tokenErrorCodeInvalidRequest, Description: "invalid encoding for client id"}
+		}
+		tr.ClientSecret, err = url.QueryUnescape(cs)
+		if err != nil {
+			return nil, &tokenError{Code: tokenErrorCodeInvalidRequest, Description: "invalid encoding for client secret"}
+		}
+
 	} else {
 		tr.ClientID = req.FormValue("client_id")
 		tr.ClientSecret = req.FormValue("client_secret")

--- a/core/oauth2_token_test.go
+++ b/core/oauth2_token_test.go
@@ -99,6 +99,26 @@ func TestParseToken(t *testing.T) {
 			WantErr:     true,
 			WantErrCode: tokenErrorCodeInvalidRequest,
 		},
+		{
+			Name: "Escaped basic auth creds", // https://tools.ietf.org/html/rfc6749#section-2.3.1
+			Req: func() *http.Request {
+				req := queryReq(map[string]string{
+					"code":         "acode",
+					"redirect_uri": "https://redirect",
+					"grant_type":   "authorization_code",
+				})()
+
+				req.SetBasicAuth(url.QueryEscape("cl#i$nt"), url.QueryEscape("sec=ret%"))
+				return req
+			},
+			Want: &tokenRequest{
+				GrantType:    GrantTypeAuthorizationCode,
+				Code:         "acode",
+				RedirectURI:  "https://redirect",
+				ClientID:     "cl#i$nt",
+				ClientSecret: "sec=ret%",
+			},
+		},
 	} {
 		t.Run(tc.Name, func(t *testing.T) {
 			resp, err := parseTokenRequest(tc.Req())


### PR DESCRIPTION
According to the spec (https://tools.ietf.org/html/rfc6749#section-2.3.1), the
basic auth creds should be URL encoded.

Unencode them when parsing the request.