### PR TITLE
core: Allow Session Manager to provide new ID's

### DIFF
--- a/cmd/oidc-example-op/state.go
+++ b/cmd/oidc-example-op/state.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/base64"
 	"fmt"
 
 	"github.com/golang/protobuf/jsonpb"
@@ -27,6 +29,14 @@ func newStubSMGR() *storage {
 	return &storage{
 		sessions: map[string]*session{},
 	}
+}
+
+func (s *storage) NewID() string {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		panic(fmt.Errorf("can't create ID, rand.Read failed: %w", err))
+	}
+	return base64.RawURLEncoding.EncodeToString(b)
 }
 
 func (s *storage) GetSession(_ context.Context, sessionID string, into core.Session) (bool, error) {

--- a/core/shared_test.go
+++ b/core/shared_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
+	"encoding/base64"
 	"fmt"
 
 	"github.com/golang/protobuf/jsonpb"
@@ -51,6 +52,18 @@ func newStubSMGR() *stubSMGR {
 	return &stubSMGR{
 		sessions: map[string]string{},
 	}
+}
+
+func (s *stubSMGR) NewID() string {
+	return mustGenerateID()
+}
+
+func mustGenerateID() string {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		panic(fmt.Errorf("can't create ID, rand.Read failed: %w", err))
+	}
+	return base64.RawURLEncoding.EncodeToString(b)
 }
 
 func (s *stubSMGR) GetSession(_ context.Context, sessionID string, into Session) (found bool, err error) {


### PR DESCRIPTION
The ideal ID format might depend on the storage being used by the session
manager.

Allow it to generate IDs in the appropriate format, rather than using an
internal generator.