### PR TITLE
Use url-safe encoder to marshal tokens

### DIFF
--- a/core/token.go
+++ b/core/token.go
@@ -62,11 +62,15 @@ func marshalToken(user *corev1beta1.UserToken) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("couldn't marshal user token to proto: %w", err)
 	}
-	return base64.RawStdEncoding.EncodeToString(b), nil
+	return base64.RawURLEncoding.EncodeToString(b), nil
 }
 
 func unmarshalToken(tok string) (*corev1beta1.UserToken, error) {
-	b, err := base64.RawStdEncoding.DecodeString(tok)
+	b, err := base64.RawURLEncoding.DecodeString(tok)
+	if _, ok := err.(base64.CorruptInputError); ok {
+		// token may have been encoded with previously used base64.RawStdEncoding encoder
+		b, err = base64.RawStdEncoding.DecodeString(tok)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("base64 decode of token failed: %w", err)
 	}

--- a/core/token_test.go
+++ b/core/token_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 )
 
@@ -46,5 +47,24 @@ func TestTokens(t *testing.T) {
 	}
 	if eq {
 		t.Error("want: tokens to not be equal, got equal")
+	}
+}
+
+func TestUnmarshalToken(t *testing.T) {
+	encodedURLToken := "ChZXb2ozLXFJS0xEbzg5aDlaYXNaTmF3EjAezFlLpPCa5dMEOTNT0rpUnQUQrFZnKxV4AMvV2UzI7HXlLSSem-PVW-68oJDOA08"
+	encodedStdToken := "ChZXb2ozLXFJS0xEbzg5aDlaYXNaTmF3EjAezFlLpPCa5dMEOTNT0rpUnQUQrFZnKxV4AMvV2UzI7HXlLSSem+PVW+68oJDOA08"
+
+	urlToken, err := unmarshalToken(encodedURLToken)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stdToken, err := unmarshalToken(encodedStdToken)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !proto.Equal(urlToken, stdToken) {
+		t.Error("want: url encoded and std encoded tokens to be equal, got not equal")
 	}
 }


### PR DESCRIPTION
User tokens are marshalled with a url-safe encoder. Unmarshalling first tries to decode a url-safe encoded token, but falls back, trying to decode a standard encoded token.

This specifically fixes a problem caused by Artifactory attempting to decode the token that was not url-safe (included a `+` character).