### PR TITLE
Add userinfo support to client

### DIFF
--- a/client.go
+++ b/client.go
@@ -285,9 +285,8 @@ func (c *Client) Userinfo(ctx context.Context, token *Token) (*Userinfo, error) 
 }
 
 type wrapTokenSource struct {
-	ts     oauth2.TokenSource
-	c      *Client
-	notify func(t *Token)
+	ts oauth2.TokenSource
+	c  *Client
 }
 
 func (c *Client) TokenSource(ctx context.Context, t *Token) TokenSource {

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -298,7 +298,7 @@ func (s *stubSMGR) DeleteSession(ctx context.Context, sessionID string) error {
 
 // expireAccessTokens will set all the access token expirations to a time before
 // now.
-func (s *stubSMGR) expireAccessTokens(ctx context.Context) error {
+func (s *stubSMGR) expireAccessTokens(_ context.Context) error {
 	for id, sd := range s.sessions {
 		sm := map[string]interface{}{}
 		if err := json.Unmarshal([]byte(sd), &sm); err != nil {


### PR DESCRIPTION
This adds a Userinfo method to the OIDC client. This takes a token, and will
fetch the userinfo if the endpoint is provided.

It fetches this into a standard Claims object, and uses this to validate the
returned subject. This can then be extracted out into whatever format using the
Unmarshal method it provides.

An updated token is returned, this can be used to capture the updated refresh
token if a refresh was needed.

Overall this does feel a little wonky, so I think it'll need some deeper
thought. Would appreciate any feedback on that.
