### PR TITLE
Allow per auth code URL scopes

### DIFF
--- a/client.go
+++ b/client.go
@@ -100,10 +100,10 @@ func SetNonce(nonce string) AuthCodeOption {
 	}
 }
 
-// AddScope adds an additional scope request to this URL only
-func AddScope(scope string) AuthCodeOption {
+// AddScopes adds additional scopes to this URL only
+func AddScopes(scopes []string) AuthCodeOption {
 	return func(cfg *authCodeCfg) {
-		cfg.addlScopes = append(cfg.addlScopes, scope)
+		cfg.addlScopes = scopes
 	}
 }
 


### PR DESCRIPTION
Discovered clients will usually live for a longer lifetime than a single
request. As such, allow specifying the scopes for each request, rather than at
the client level.