### PR TITLE
Set content-type correctly on userinfo

### DIFF
--- a/core/oidc.go
+++ b/core/oidc.go
@@ -721,6 +721,8 @@ func (o *OIDC) Userinfo(w http.ResponseWriter, req *http.Request, handler func(w
 		SessionID: uaccess.SessionId,
 	}
 
+	w.Header().Set("Content-Type", "application/json")
+
 	if err := handler(w, uireq); err != nil {
 		herr := &httpError{Code: http.StatusInternalServerError, Cause: err, CauseMsg: "error in user handler"}
 		_ = writeError(w, req, herr)


### PR DESCRIPTION
We should always be returning JSON, so set the content type appropriately.