### PR TITLE
Allow token handlers to signal unauthorized requests

### DIFF
--- a/core/oidc.go
+++ b/core/oidc.go
@@ -152,7 +152,7 @@ type AuthorizationRequest struct {
 // StartAuthorization can be used to handle a request to the auth endpoint. It
 // will parse and validate the incoming request, returning a unique identifier.
 // If an error was returned, it should be assumed that this has been returned to
-// the user appropriately. Otherwise, no response will be written. The caller
+// the called appropriately. Otherwise, no response will be written. The caller
 // can then use this request to implement the appropriate auth flow. The authID
 // should be kept and treated as sensitive - it will be used to mark the request
 // as Authorized.


### PR DESCRIPTION
Calls to issue/refresh a token may be presented with a valid session, but the
handler might decide to deny it anyway.

Make this possible by checking the returned error from the handler to see if it
indicates the request failed because it was unauthorized, and return an
appropriate response to the caller.

Fixes #29