### PR TITLE
Scope scopes to AuthURL calls correctly

### DIFF
--- a/client.go
+++ b/client.go
@@ -127,7 +127,8 @@ func (c *Client) AuthCodeURL(state string, opts ...AuthCodeOption) string {
 		aopts = append(aopts, oauth2.SetAuthURLParam("nonce", accfg.nonce))
 	}
 
-	oc := &c.o2cfg
+	// copy to avoid modifying the original
+	oc := c.o2cfg
 	oc.Scopes = append(oc.Scopes, accfg.addlScopes...)
 
 	return oc.AuthCodeURL(state, aopts...)

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,36 @@
+package oidc
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+
+	"golang.org/x/oauth2"
+)
+
+func TestAuthURLOpts(t *testing.T) {
+	c := &Client{
+		o2cfg: oauth2.Config{
+			ClientID: "cid",
+			Endpoint: oauth2.Endpoint{
+				AuthURL: "https://auth",
+			},
+			Scopes:      []string{"openid"},
+			RedirectURL: "https://redir",
+		},
+	}
+
+	// make sure scopes don't cross invocations
+	_ = c.AuthCodeURL("state", AddScopes([]string{"scope1", "scope2"}))
+	u2 := c.AuthCodeURL("state", AddScopes([]string{"scope3"}))
+
+	pu2, err := url.Parse(u2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	scopes := strings.Split(pu2.Query().Get("scope"), " ")
+	if len(scopes) != 2 {
+		t.Errorf("want 2 scopes, found: %v", scopes)
+	}
+}


### PR DESCRIPTION
We were grabbing a pointer rather than copying the object, so mutating
scopes appended to the base Client on each invocation. Copy the oauth2
config instead, so we don't leak these