### PR TITLE
Oauth2 Token Exchange Error Responses

### DIFF
--- a/client.go
+++ b/client.go
@@ -162,11 +162,14 @@ func (c *Client) SetRedirectURL(redirectURL string) {
 	c.o2cfg.RedirectURL = redirectURL
 }
 
-// Exchange the returned code for a set of tokens
+// Exchange the returned code for a set of tokens. If the exchange fails and
+// returns an oauth2 error reponse, the returned error will be an
+// `*github.com/parot/oidc/oauth2.TokenError`. If a HTTP error occurs, a
+// *HTTPError will be returned.
 func (c *Client) Exchange(ctx context.Context, code string) (*Token, error) {
 	t, err := c.o2cfg.Exchange(ctx, code)
 	if err != nil {
-		return nil, fmt.Errorf("exchanging code: %v", err)
+		return nil, parseExchangeError(err)
 	}
 
 	return c.oauth2Token(ctx, t)

--- a/client.go
+++ b/client.go
@@ -163,7 +163,7 @@ func (c *Client) SetRedirectURL(redirectURL string) {
 }
 
 // Exchange the returned code for a set of tokens. If the exchange fails and
-// returns an oauth2 error reponse, the returned error will be an
+// returns an oauth2 error response, the returned error will be an
 // `*github.com/parot/oidc/oauth2.TokenError`. If a HTTP error occurs, a
 // *HTTPError will be returned.
 func (c *Client) Exchange(ctx context.Context, code string) (*Token, error) {

--- a/core/oauth2_errors_test.go
+++ b/core/oauth2_errors_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/pardot/oidc/oauth2"
 	"golang.org/x/text/language"
 	"golang.org/x/text/search"
 )
@@ -96,20 +97,20 @@ func TestWriteError(t *testing.T) {
 		},
 		{
 			Name: "Token error should return JSON details",
-			Err:  &tokenError{Code: tokenErrorCodeInvalidGrant, Description: "grant is bad", ErrorURI: "https://error/info"},
+			Err:  &oauth2.TokenError{ErrorCode: oauth2.TokenErrorCodeInvalidGrant, Description: "grant is bad", ErrorURI: "https://error/info"},
 			Cmp: func(t *testing.T, rec *httptest.ResponseRecorder) {
 				if rec.Code != http.StatusBadRequest {
 					t.Errorf("want 400, got %d", rec.Code)
 				}
 
-				te := &tokenError{}
+				te := &oauth2.TokenError{}
 
 				if err := json.NewDecoder(rec.Body).Decode(te); err != nil {
 					t.Fatalf("failed to unmarshal response JSON: %v", err)
 				}
 
-				if te.Code != tokenErrorCodeInvalidGrant {
-					t.Errorf("want code %s, got %s", tokenErrorCodeInvalidClient, te.Code)
+				if te.ErrorCode != oauth2.TokenErrorCodeInvalidGrant {
+					t.Errorf("want code %s, got %s", oauth2.TokenErrorCodeInvalidClient, te.ErrorCode)
 				}
 
 				if te.Description != "grant is bad" {
@@ -119,7 +120,7 @@ func TestWriteError(t *testing.T) {
 		},
 		{
 			Name: "Token error can set www-authenticate header",
-			Err:  &tokenError{Code: tokenErrorCodeInvalidClient, WWWAuthenticate: "Basic"},
+			Err:  &oauth2.TokenError{ErrorCode: oauth2.TokenErrorCodeInvalidClient, WWWAuthenticate: "Basic"},
 			Cmp: func(t *testing.T, rec *httptest.ResponseRecorder) {
 				if rec.Code != http.StatusUnauthorized {
 					t.Errorf("want 401, got %d", rec.Code)

--- a/core/oauth2_token_test.go
+++ b/core/oauth2_token_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/pardot/oidc/oauth2"
 )
 
 func TestParseToken(t *testing.T) {
@@ -17,7 +18,7 @@ func TestParseToken(t *testing.T) {
 		Name        string
 		Req         func() *http.Request
 		WantErr     bool
-		WantErrCode tokenErrorCode
+		WantErrCode oauth2.TokenErrorCode
 		Want        *tokenRequest
 	}{
 		{
@@ -72,7 +73,7 @@ func TestParseToken(t *testing.T) {
 				"client_secret": "secret",
 			}),
 			WantErr:     true,
-			WantErrCode: tokenErrorCodeInvalidGrant,
+			WantErrCode: oauth2.TokenErrorCodeInvalidGrant,
 		},
 		{
 			Name: "Valid refresh request succeeds",
@@ -97,7 +98,7 @@ func TestParseToken(t *testing.T) {
 				"client_secret": "secret",
 			}),
 			WantErr:     true,
-			WantErrCode: tokenErrorCodeInvalidRequest,
+			WantErrCode: oauth2.TokenErrorCodeInvalidRequest,
 		},
 		{
 			Name: "Escaped basic auth creds", // https://tools.ietf.org/html/rfc6749#section-2.3.1
@@ -128,13 +129,13 @@ func TestParseToken(t *testing.T) {
 			if !tc.WantErr && err != nil {
 				t.Fatalf("want no error, got: %v", err)
 			}
-			if tc.WantErrCode != tokenErrorCode("") {
-				terr, ok := err.(*tokenError)
+			if tc.WantErrCode != oauth2.TokenErrorCode("") {
+				terr, ok := err.(*oauth2.TokenError)
 				if !ok {
 					t.Fatalf("want tokenError, got: %v of type %T", err, err)
 				}
-				if tc.WantErrCode != terr.Code {
-					t.Fatalf("want err code %s, got: %s", tc.WantErrCode, terr.Code)
+				if tc.WantErrCode != terr.ErrorCode {
+					t.Fatalf("want err code %s, got: %s", tc.WantErrCode, terr.ErrorCode)
 				}
 			}
 

--- a/errors.go
+++ b/errors.go
@@ -10,7 +10,7 @@ import (
 	xoauth2 "golang.org/x/oauth2"
 )
 
-// HTTPError indicates a generic HTTP error occured during an interaction. It
+// HTTPError indicates a generic HTTP error occurred during an interaction. It
 // exposes details about the returned response, as well as the original error
 type HTTPError struct {
 	Response *http.Response

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,58 @@
+package oidc
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/pardot/oidc/oauth2"
+	xoauth2 "golang.org/x/oauth2"
+)
+
+// HTTPError indicates a generic HTTP error occured during an interaction. It
+// exposes details about the returned response, as well as the original error
+type HTTPError struct {
+	Response *http.Response
+	Body     []byte
+	Cause    error
+}
+
+func (h *HTTPError) Error() string {
+	return fmt.Sprintf("http status %s: %s", h.Response.Status, string(h.Body))
+}
+
+func (h *HTTPError) Unwrap() error {
+	return h.Cause
+}
+
+// parseTokenError takes an error returned from the oauth2.Exchange method, and
+// returns the first match of:
+// * an oauth2.TokenError if the response was 400 or 401, and contains a
+// correctly formatted response in the body
+// * a HttpError if a general HTTP error response was returned
+// * A generic error for all other errors
+func parseExchangeError(err error) error {
+	var rerr *xoauth2.RetrieveError
+	if errors.As(err, &rerr) {
+		// set this up as the default case if we can't handle the error more intelligently
+		herr := HTTPError{
+			Response: rerr.Response,
+			Body:     rerr.Body,
+			// ignore cause to not make x/oauth2 part of the contract
+		}
+
+		if rerr.Response.StatusCode == 400 || rerr.Response.StatusCode == 401 {
+			// this should be a token error. Try and parse, else fall back to a http error
+			terr := oauth2.TokenError{}
+			if err := json.Unmarshal(rerr.Body, &terr); err != nil {
+				// not formatted correctly/non-standard, treat as HTTP
+				return &herr
+			}
+			terr.WWWAuthenticate = rerr.Response.Header.Get("www-authenticate")
+			return &terr
+		}
+		return &herr
+	}
+	return fmt.Errorf("error exchanging token: %v", err)
+}

--- a/errors_test.go
+++ b/errors_test.go
@@ -5,17 +5,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	xoauth2 "golang.org/x/oauth2"
 )
-
-var errCmp = cmp.Comparer(func(x, y error) bool {
-	// Two errors are equal if either Is the other.
-	//
-	// We need to perform the test in both directions because cmp requires
-	// comparer functions to be symmetric, but errors.Is is not.
-	return errors.Is(x, y) || errors.Is(y, x)
-})
 
 func TestParseExchangeError(t *testing.T) {
 	for _, tc := range []struct {

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,76 @@
+package oidc
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	xoauth2 "golang.org/x/oauth2"
+)
+
+var errCmp = cmp.Comparer(func(x, y error) bool {
+	// Two errors are equal if either Is the other.
+	//
+	// We need to perform the test in both directions because cmp requires
+	// comparer functions to be symmetric, but errors.Is is not.
+	return errors.Is(x, y) || errors.Is(y, x)
+})
+
+func TestParseExchangeError(t *testing.T) {
+	for _, tc := range []struct {
+		Name string
+		In   error
+		Want string
+	}{
+		{
+			Name: "Generic error",
+			In:   errors.New("Some rando thing happened"),
+			Want: "error exchanging token: Some rando thing happened",
+		},
+		{
+			Name: "Invalid Grant error",
+			In: &xoauth2.RetrieveError{
+				Response: &http.Response{
+					StatusCode: 400,
+					Status:     "400 Bad Request",
+				},
+				Body: []byte(`{"error": "invalid_grant", "error_description":"authentication failure"}`),
+			},
+			Want: "invalid_grant error in token request: authentication failure",
+		},
+		{
+			Name: "Internal server error",
+			In: &xoauth2.RetrieveError{
+				Response: &http.Response{
+					StatusCode: 500,
+					Status:     "500 Internal Server Error",
+				},
+				Body: []byte(`Boomtown`),
+			},
+			Want: "http status 500 Internal Server Error: Boomtown",
+		},
+		{
+			Name: "401 error",
+			In: &xoauth2.RetrieveError{
+				Response: &http.Response{
+					StatusCode: 401,
+					Status:     "401 Unauthorized",
+					Header: http.Header{
+						http.CanonicalHeaderKey("www-authenticate"): []string{"Basic"},
+					},
+				},
+				Body: []byte(`{"error": "invalid_client", "error_description":"auth or something"}`),
+			},
+			Want: "invalid_client error in token request: auth or something",
+		},
+	} {
+		t.Run(tc.Name, func(t *testing.T) {
+			got := parseExchangeError(tc.In)
+
+			if got.Error() != tc.Want {
+				t.Errorf("want: %s, got: %s", tc.Want, got.Error())
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -12,10 +12,11 @@ require (
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.4.0 // indirect
 	golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392
-	golang.org/x/net v0.0.0-20190923162816-aa69164e4478 // indirect
+	golang.org/x/net v0.0.0-20191004110552-13f9640d40b9 // indirect
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
+	golang.org/x/sys v0.0.0-20191022100944-742c48ecaeb7 // indirect
 	golang.org/x/text v0.3.2
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/square/go-jose.v2 v2.4.0
-	gopkg.in/yaml.v2 v2.2.4 // indirect
+	gopkg.in/yaml.v2 v2.2.8 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -31,14 +31,16 @@ golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392/go.mod h1:/lpIB1dKB+9EgE3
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
-golang.org/x/net v0.0.0-20190923162816-aa69164e4478 h1:l5EDrHhldLYb3ZRHDUhXF7Om7MvYXnkV9/iQNo1lX6g=
-golang.org/x/net v0.0.0-20190923162816-aa69164e4478/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20191004110552-13f9640d40b9 h1:rjwSpXsdiK0dV8/Naq3kAw9ymfAeJIyd0upUIElB+lI=
+golang.org/x/net v0.0.0-20191004110552-13f9640d40b9/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 h1:SVwTIAaPC2U/AvvLNZ2a7OVsmBpC8L5BlwK1whH3hm0=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190922100055-0a153f010e69 h1:rOhMmluY6kLMhdnrivzec6lLgaVbMHMn2ISQXJeJ5EM=
 golang.org/x/sys v0.0.0-20190922100055-0a153f010e69/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191022100944-742c48ecaeb7 h1:HmbHVPwrPEKPGLAcHSrMe6+hqSUlvZU0rab6x5EXfGU=
+golang.org/x/sys v0.0.0-20191022100944-742c48ecaeb7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
@@ -51,5 +53,5 @@ gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/square/go-jose.v2 v2.4.0 h1:0kXPskUMGAXXWJlP05ktEMOV0vmzFQUWw6d+aZJQU8A=
 gopkg.in/square/go-jose.v2 v2.4.0/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
-gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
+gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/oauth2/doc.go
+++ b/oauth2/doc.go
@@ -1,0 +1,3 @@
+// Package oauth2 implements base primitives for parsing oauth2 messages and
+// errors
+package oauth2

--- a/oauth2/errors.go
+++ b/oauth2/errors.go
@@ -1,0 +1,80 @@
+package oauth2
+
+import "fmt"
+
+// TokenErrorCode are the types of error that can be returned
+type TokenErrorCode string
+
+// https://tools.ietf.org/html/rfc6749#section-5.2
+// nolint:unused,varcheck,deadcode
+const (
+	// TokenErrorCodeInvalidRequest: The request is missing a required
+	// parameter, includes an unsupported parameter value (other than grant
+	// type), repeats a parameter, includes multiple credentials, utilizes more
+	// than one mechanism for authenticating the client, or is otherwise
+	// malformed.
+	TokenErrorCodeInvalidRequest TokenErrorCode = "invalid_request"
+	// TokenErrorCodeInvalidClient: Client authentication failed (e.g., unknown
+	// client, no client authentication included, or unsupported authentication
+	// method).  The authorization server MAY return an HTTP 401 (Unauthorized)
+	// status code to indicate which HTTP authentication schemes are supported.
+	// If the client attempted to authenticate via the "Authorization" request
+	// header field, the authorization server MUST respond with an HTTP 401
+	// (Unauthorized) status code and include the "WWW-Authenticate" response
+	// header field matching the authentication scheme used by the client.
+	TokenErrorCodeInvalidClient TokenErrorCode = "invalid_client"
+	// TokenErrorCodeInvalidGrant: The provided authorization grant (e.g.,
+	// authorization code, resource owner credentials) or refresh token is
+	// invalid, expired, revoked, does not match the redirection URI used in the
+	// authorization request, or was issued to another client.=
+	TokenErrorCodeInvalidGrant TokenErrorCode = "invalid_grant"
+	// TokenErrorCodeUnauthorizedClient: The authenticated client is not
+	// authorized to use this authorization grant type.
+	TokenErrorCodeUnauthorizedClient TokenErrorCode = "unauthorized_client"
+	// TokenErrorCodeUnsupportedGrantType: The authorization grant type is not
+	// supported by the authorization server.
+	TokenErrorCodeUnsupportedGrantType TokenErrorCode = "unsupported_grant_type"
+	// TokenErrorCodeInvalidScope: The requested scope is invalid, unknown,
+	// malformed, or exceeds the scope granted by the resource owner.
+	TokenErrorCodeInvalidScope TokenErrorCode = "invalid_scope"
+)
+
+// TokenError represents an error returned from calling the token endpoint.
+//
+// https://tools.ietf.org/html/rfc6749#section-5.2
+type TokenError struct {
+	// ErrorCode indicates the type of error that occurred
+	ErrorCode TokenErrorCode `json:"error,omitempty"`
+	// Description: OPTIONAL.  Human-readable ASCII [USASCII] text providing
+	// additional information, used to assist the client developer in
+	// understanding the error that occurred. Values for the "error_description"
+	// parameter MUST NOT include characters outside the set %x20-21 / %x23-5B /
+	// %x5D-7E.
+	Description string `json:"error_description,omitempty"`
+	// ErrorURI: OPTIONAL.  A URI identifying a human-readable web page with
+	// information about the error, used to provide the client developer with
+	// additional information about the error. Values for the "error_uri"
+	// parameter MUST conform to the URI-reference syntax and thus MUST NOT
+	// include characters outside the set %x21 / %x23-5B / %x5D-7E.
+	ErrorURI string `json:"error_uri,omitempty"`
+	// 	WWWAuthenticate is set when an invalid_client error is returned, and
+	// 	that response indicates the authentication scheme to be used by the
+	// 	client
+	WWWAuthenticate string `json:"-"`
+	// Cause wraps any upstream error that resulted in this token being issued,
+	// if this error should be unrwappable
+	Cause error `json:"-"`
+}
+
+// Error returns a string representing this error
+func (t *TokenError) Error() string {
+	str := fmt.Sprintf("%s error in token request: %s", t.ErrorCode, t.Description)
+	if t.Cause != nil {
+		str = fmt.Sprintf("%s (cause: %s)", str, t.Cause.Error())
+	}
+	return str
+}
+
+func (t *TokenError) Unwrap() error {
+	return t.Cause
+}

--- a/oauth2/errors.go
+++ b/oauth2/errors.go
@@ -26,7 +26,7 @@ const (
 	// TokenErrorCodeInvalidGrant: The provided authorization grant (e.g.,
 	// authorization code, resource owner credentials) or refresh token is
 	// invalid, expired, revoked, does not match the redirection URI used in the
-	// authorization request, or was issued to another client.=
+	// authorization request, or was issued to another client.
 	TokenErrorCodeInvalidGrant TokenErrorCode = "invalid_grant"
 	// TokenErrorCodeUnauthorizedClient: The authenticated client is not
 	// authorized to use this authorization grant type.


### PR DESCRIPTION
This updates the OIDC client Exchange method to return either a parse Oauth2 error type, or a more descriptive HTTP error type where appropriate. This will aid consumers in managing these cases better.