### PR TITLE
Support optional port low/high range

### DIFF
--- a/clitoken/opener.go
+++ b/clitoken/opener.go
@@ -3,6 +3,7 @@ package clitoken
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"runtime"
 )
@@ -36,7 +37,11 @@ type CommandOpener struct {
 }
 
 func (o *CommandOpener) Open(ctx context.Context, url string) error {
-	return exec.CommandContext(ctx, o.CommandName, url).Run()
+	cmd := exec.CommandContext(ctx, o.CommandName, url)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
 }
 
 // EchoOpener opens a URL by printing it to the console for the user to

--- a/clitoken/opener.go
+++ b/clitoken/opener.go
@@ -39,7 +39,6 @@ type CommandOpener struct {
 func (o *CommandOpener) Open(ctx context.Context, url string) error {
 	cmd := exec.CommandContext(ctx, o.CommandName, url)
 	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
 }

--- a/cmd/oidccli/main.go
+++ b/cmd/oidccli/main.go
@@ -23,6 +23,8 @@ type baseOpts struct {
 	Issuer       string
 	ClientID     string
 	ClientSecret string
+	PortLow      int
+	PortHigh     int
 	Offline      bool
 	SkipCache    bool
 }
@@ -41,6 +43,8 @@ func main() {
 	baseFs.StringVar(&baseFlags.Issuer, "issuer", baseFlags.Issuer, "OIDC Issuer URL (required)")
 	baseFs.StringVar(&baseFlags.ClientID, "client-id", baseFlags.ClientID, "OIDC Client ID (required)")
 	baseFs.StringVar(&baseFlags.ClientSecret, "client-secret", baseFlags.ClientSecret, "OIDC Client Secret")
+	baseFs.IntVar(&baseFlags.PortLow, "port-low", 0, "Lowest TCP port to bind on localhost for callbacks. By default, a port will be randomly assigned by the operating system.")
+	baseFs.IntVar(&baseFlags.PortHigh, "port-high", 0, "Highest TCP port to bind on localhost for callbacks. By default, a port will be randomly assigned by the operating system.")
 	baseFs.BoolVar(&baseFlags.Offline, "offline", baseFlags.Offline, "Offline use (request refresh token). This token will be cached locally, can be used to avoid re-launching the auth flow when the token expires")
 	baseFs.BoolVar(&baseFlags.SkipCache, "skip-cache", baseFlags.SkipCache, "Do not perform any local caching on token")
 
@@ -138,7 +142,7 @@ func main() {
 
 	var ts oidc.TokenSource
 
-	ts, err = clitoken.NewSource(client)
+	ts, err = clitoken.NewSource(client, clitoken.WithPortRange(baseFlags.PortLow, baseFlags.PortHigh))
 	if err != nil {
 		fmt.Printf("getting cli token source: %v", err)
 		os.Exit(1)

--- a/tokencache/cache.go
+++ b/tokencache/cache.go
@@ -317,12 +317,12 @@ func (e *EncryptedFileCredentialCache) promptFuncOrDefault() PassphrasePromptFun
 			return cp, nil
 		}
 
-		fmt.Printf("%s: ", prompt)
+		fmt.Fprintf(os.Stderr, "%s: ", prompt)
 		passphrase, err := terminal.ReadPassword(int(os.Stdin.Fd()))
 		if err != nil {
 			return "", err
 		}
-		fmt.Println()
+		fmt.Fprintln(os.Stderr)
 
 		return string(passphrase), nil
 	}


### PR DESCRIPTION
Some OIDC servers support only a limited range of redirect URLs. In those cases, a user could choose to add http://localhost:5000, 5001, 5002, etc. up to some reasonable number, then configure -port-low=5000, -port-high=... It is less reliable than letting the operating system assign one, but as long as there are enough ports in the range, it's likely to work for most use cases.

Additionally, allow `Opener` to communicate with the user over stdin/stderr, but reserve stdout for our own use. This allows interaction with the user in a limited way.