### PR TITLE
Parse scientific notation unixtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# deci
+# oidc
 
 Experimental OIDC/Webauthn server

--- a/claims.go
+++ b/claims.go
@@ -3,6 +3,7 @@ package oidc
 import (
 	"encoding/json"
 	"fmt"
+	"math/big"
 	"strconv"
 	"time"
 )
@@ -249,10 +250,16 @@ func (u UnixTime) MarshalJSON() ([]byte, error) {
 }
 
 func (u *UnixTime) UnmarshalJSON(b []byte) error {
-	p, err := strconv.ParseInt(string(b), 10, 64)
+	// Default to round down (expire sooner)
+	flt, _, err := big.ParseFloat(string(b), 10, 64, big.ToNegativeInf)
 	if err != nil {
 		return fmt.Errorf("failed to parse UnixTime: %v", err)
 	}
-	*u = UnixTime(p)
+	var i = new(big.Int)
+	i, _ = flt.Int(i)
+	if err != nil {
+		return fmt.Errorf("failed to parse UnixTime: %v", err)
+	}
+	*u = UnixTime(i.Int64())
 	return nil
 }

--- a/claims.go
+++ b/claims.go
@@ -3,7 +3,6 @@ package oidc
 import (
 	"encoding/json"
 	"fmt"
-	"math/big"
 	"strconv"
 	"time"
 )
@@ -250,16 +249,10 @@ func (u UnixTime) MarshalJSON() ([]byte, error) {
 }
 
 func (u *UnixTime) UnmarshalJSON(b []byte) error {
-	// Default to round down (expire sooner)
-	flt, _, err := big.ParseFloat(string(b), 10, 64, big.ToNegativeInf)
+	flt, err := strconv.ParseFloat(string(b), 64)
 	if err != nil {
 		return fmt.Errorf("failed to parse UnixTime: %v", err)
 	}
-	var i = new(big.Int)
-	i, _ = flt.Int(i)
-	if err != nil {
-		return fmt.Errorf("failed to parse UnixTime: %v", err)
-	}
-	*u = UnixTime(i.Int64())
+	*u = UnixTime(int64(flt))
 	return nil
 }

--- a/claims_test.go
+++ b/claims_test.go
@@ -132,6 +132,23 @@ func TestIDTokenUnmarshaling(t *testing.T) {
 				Audience: Audience{"aud1", "aud2"},
 			},
 		},
+		{
+			Name: "scientific notation",
+			JSON: `{
+  "aud": "aud",
+  "exp": 1.601386279e+09,
+  "hello": "world",
+  "iss": "http://issuer"
+}`,
+			WantToken: Claims{
+				Issuer:   "http://issuer",
+				Audience: Audience{"aud"},
+				Expiry:   1601386279,
+				Extra: map[string]interface{}{
+					"hello": "world",
+				},
+			},
+		},
 	} {
 		t.Run(tc.Name, func(t *testing.T) {
 			tok := Claims{}


### PR DESCRIPTION
Since scientific notation is valid for a [json number](https://json-schema.org/understanding-json-schema/reference/numeric.html#number), some tools output json time stamp values as for example `1.601386279e+09` for a unix timestamp. This update allows parsing claims with this json number format.