### PR TITLE
expose the token request's nonce

### DIFF
--- a/core/oauth2_token.go
+++ b/core/oauth2_token.go
@@ -25,7 +25,6 @@ type tokenRequest struct {
 	RedirectURI  string
 	ClientID     string
 	ClientSecret string
-	Nonce        string
 }
 
 // parseTokenRequest parses the information from a request for an access token.
@@ -40,7 +39,6 @@ func parseTokenRequest(req *http.Request) (*tokenRequest, error) {
 		RedirectURI:  req.FormValue("redirect_uri"),
 		Code:         req.FormValue("code"),
 		RefreshToken: req.FormValue("refresh_token"),
-		Nonce:        req.FormValue("nonce"),
 	}
 
 	// Auth the request

--- a/core/oauth2_token.go
+++ b/core/oauth2_token.go
@@ -25,6 +25,7 @@ type tokenRequest struct {
 	RedirectURI  string
 	ClientID     string
 	ClientSecret string
+	Nonce        string
 }
 
 // parseTokenRequest parses the information from a request for an access token.
@@ -39,6 +40,7 @@ func parseTokenRequest(req *http.Request) (*tokenRequest, error) {
 		RedirectURI:  req.FormValue("redirect_uri"),
 		Code:         req.FormValue("code"),
 		RefreshToken: req.FormValue("refresh_token"),
+		Nonce:        req.FormValue("nonce"),
 	}
 
 	// Auth the request

--- a/core/oidc.go
+++ b/core/oidc.go
@@ -467,9 +467,10 @@ func (o *OIDC) token(ctx context.Context, req *tokenRequest, handler func(req *T
 		SessionRefreshable: strsContains(sess.Authorization.Scopes, "offline_access"),
 		IsRefresh:          isRefresh,
 		Nonce:              sess.Request.Nonce,
-		authTime:           sess.Authorization.AuthorizedAt,
-		authReq:            sess.Request,
-		now:                o.now,
+
+		authTime: sess.Authorization.AuthorizedAt,
+		authReq:  sess.Request,
+		now:      o.now,
 	}
 
 	tresp, err := handler(tr)

--- a/core/oidc.go
+++ b/core/oidc.go
@@ -339,9 +339,14 @@ func (t *TokenRequest) PrefillIDToken(iss, sub string, expires time.Time) oidc.C
 		AMR:      t.Authorization.AMR,
 		IssuedAt: oidc.NewUnixTime(t.now()),
 		AuthTime: oidc.NewUnixTime(t.authTime),
-		Nonce:    t.authReq.Nonce,
+		Nonce:    t.Nonce(),
 		Extra:    map[string]interface{}{},
 	}
+}
+
+// Nonce returns the originally passed nonce, if present
+func (t *TokenRequest) Nonce() string {
+	return t.authReq.Nonce
 }
 
 // TokenResponse is returned by the token endpoint handler, indicating what it

--- a/core/oidc.go
+++ b/core/oidc.go
@@ -455,6 +455,10 @@ func (o *OIDC) token(ctx context.Context, req *tokenRequest, handler func(req *T
 		return nil, &httpError{Code: http.StatusInternalServerError, Message: "internal error", CauseMsg: "session authorization is nil"}
 	}
 
+	var nonce string
+	if sess.Request != nil {
+		nonce = sess.Request.Nonce
+	}
 	tr := &TokenRequest{
 		SessionID: sess.ID,
 		ClientID:  req.ClientID,
@@ -466,7 +470,7 @@ func (o *OIDC) token(ctx context.Context, req *tokenRequest, handler func(req *T
 		GrantType:          req.GrantType,
 		SessionRefreshable: strsContains(sess.Authorization.Scopes, "offline_access"),
 		IsRefresh:          isRefresh,
-		Nonce:              req.Nonce,
+		Nonce:              nonce,
 
 		authTime: sess.Authorization.AuthorizedAt,
 		authReq:  sess.Request,

--- a/core/oidc.go
+++ b/core/oidc.go
@@ -311,6 +311,8 @@ type TokenRequest struct {
 	// IsRefresh is true if the token endpoint was called with the refresh token
 	// grant (i.e called with a refresh, rather than access token)
 	IsRefresh bool
+	// Nonce value the session sent, otherwise an empty string
+	Nonce string
 
 	authTime time.Time
 	authReq  *sessAuthRequest
@@ -339,17 +341,9 @@ func (t *TokenRequest) PrefillIDToken(iss, sub string, expires time.Time) oidc.C
 		AMR:      t.Authorization.AMR,
 		IssuedAt: oidc.NewUnixTime(t.now()),
 		AuthTime: oidc.NewUnixTime(t.authTime),
-		Nonce:    t.Nonce(),
+		Nonce:    t.Nonce,
 		Extra:    map[string]interface{}{},
 	}
-}
-
-// Nonce returns the originally passed nonce, if present
-func (t *TokenRequest) Nonce() string {
-	if t.authReq != nil {
-		return t.authReq.Nonce
-	}
-	return ""
 }
 
 // TokenResponse is returned by the token endpoint handler, indicating what it
@@ -472,6 +466,7 @@ func (o *OIDC) token(ctx context.Context, req *tokenRequest, handler func(req *T
 		GrantType:          req.GrantType,
 		SessionRefreshable: strsContains(sess.Authorization.Scopes, "offline_access"),
 		IsRefresh:          isRefresh,
+		Nonce:              req.Nonce,
 
 		authTime: sess.Authorization.AuthorizedAt,
 		authReq:  sess.Request,

--- a/core/oidc.go
+++ b/core/oidc.go
@@ -455,10 +455,6 @@ func (o *OIDC) token(ctx context.Context, req *tokenRequest, handler func(req *T
 		return nil, &httpError{Code: http.StatusInternalServerError, Message: "internal error", CauseMsg: "session authorization is nil"}
 	}
 
-	var nonce string
-	if sess.Request != nil {
-		nonce = sess.Request.Nonce
-	}
 	tr := &TokenRequest{
 		SessionID: sess.ID,
 		ClientID:  req.ClientID,
@@ -470,11 +466,10 @@ func (o *OIDC) token(ctx context.Context, req *tokenRequest, handler func(req *T
 		GrantType:          req.GrantType,
 		SessionRefreshable: strsContains(sess.Authorization.Scopes, "offline_access"),
 		IsRefresh:          isRefresh,
-		Nonce:              nonce,
-
-		authTime: sess.Authorization.AuthorizedAt,
-		authReq:  sess.Request,
-		now:      o.now,
+		Nonce:              sess.Request.Nonce,
+		authTime:           sess.Authorization.AuthorizedAt,
+		authReq:            sess.Request,
+		now:                o.now,
 	}
 
 	tresp, err := handler(tr)

--- a/core/oidc.go
+++ b/core/oidc.go
@@ -346,7 +346,10 @@ func (t *TokenRequest) PrefillIDToken(iss, sub string, expires time.Time) oidc.C
 
 // Nonce returns the originally passed nonce, if present
 func (t *TokenRequest) Nonce() string {
-	return t.authReq.Nonce
+	if t.authReq != nil {
+		return t.authReq.Nonce
+	}
+	return ""
 }
 
 // TokenResponse is returned by the token endpoint handler, indicating what it

--- a/core/oidc.go
+++ b/core/oidc.go
@@ -311,7 +311,7 @@ type TokenRequest struct {
 	// IsRefresh is true if the token endpoint was called with the refresh token
 	// grant (i.e called with a refresh, rather than access token)
 	IsRefresh bool
-	// Nonce value the session sent, otherwise an empty string
+	// Nonce from the authentication request, if specified
 	Nonce string
 
 	authTime time.Time

--- a/core/oidc_test.go
+++ b/core/oidc_test.go
@@ -293,9 +293,7 @@ func TestIDTokenPrefill(t *testing.T) {
 				},
 
 				authTime: now,
-				authReq: &sessAuthRequest{
-					Nonce: "nonce",
-				},
+				Nonce:    "nonce",
 
 				now: nowFn,
 			},

--- a/core/oidc_test.go
+++ b/core/oidc_test.go
@@ -376,6 +376,7 @@ func TestToken(t *testing.T) {
 			Authorization: &sessAuthorization{},
 			ClientID:      clientID,
 			Expiry:        time.Now().Add(1 * time.Minute),
+			Request:       &sessAuthRequest{},
 		}
 
 		if err := putSession(context.Background(), smgr, sess); err != nil {


### PR DESCRIPTION
Currently it's not possible to build an id tokens without using PrefillIDToken because the Nonce isn't available. If the preferred approach is to add this to the TokenRequest struct instead let me know.