### PR TITLE
Set `Content-Type` headers

### DIFF
--- a/discovery/configuration_handler.go
+++ b/discovery/configuration_handler.go
@@ -65,6 +65,8 @@ func NewConfigurationHandler(metadata *ProviderMetadata, opts ...ConfigurationHa
 }
 
 func (h *ConfigurationHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
 	if err := json.NewEncoder(w).Encode(h.md); err != nil {
 		http.Error(w, "Internal Error", http.StatusInternalServerError)
 		return

--- a/discovery/keys_handler.go
+++ b/discovery/keys_handler.go
@@ -51,6 +51,8 @@ func (h *KeysHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		h.lastKeysUpdate = time.Now()
 	}
 
+	w.Header().Set("Content-Type", "application/jwk-set+json")
+
 	if err := json.NewEncoder(w).Encode(h.currKeys); err != nil {
 		http.Error(w, "Internal Error", http.StatusInternalServerError)
 		return


### PR DESCRIPTION
[Section 4 of the OpenID Connect Discovery specification](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig) documents that the response "MUST be returned using the `application/json` content type".

[Section 8.5.1 of RFC 7517](https://tools.ietf.org/html/rfc7517#section-8.5.1) registers `application/jwk-set+json` as the content type for JSON Web Key Sets.