### PR TITLE
Redirect to IPv4-specific callback URL

### DIFF
--- a/clitoken/local_token_source.go
+++ b/clitoken/local_token_source.go
@@ -217,7 +217,7 @@ func (s *LocalOIDCTokenSource) Token(ctx context.Context) (*oidc.Token, error) {
 	}
 
 	// we need to update this each invocation
-	s.client.SetRedirectURL(fmt.Sprintf("http://localhost:%d/callback", tcpAddr.Port))
+	s.client.SetRedirectURL(fmt.Sprintf("http://127.0.0.1:%d/callback", tcpAddr.Port))
 
 	authURL := s.client.AuthCodeURL(state, authCodeOpts...)
 


### PR DESCRIPTION
Avoid using `localhost` for the time being which depends on `/etc/hosts` and IPv6 versus IPv4 preferences.