### PR TITLE
Make CLI Token Browser opener configurable, EchoOpener uses stderr

### DIFF
--- a/clitoken/local_token_source.go
+++ b/clitoken/local_token_source.go
@@ -126,6 +126,14 @@ func WithRenderer(renderer Renderer) LocalOIDCTokenSourceOpt {
 	}
 }
 
+// WithOpener sets a custom handler for launching URLs on the user's system.
+// This is used to kick them in to the auth flow.
+func WithOpener(opener Opener) LocalOIDCTokenSourceOpt {
+	return func(s *LocalOIDCTokenSource) {
+		s.opener = opener
+	}
+}
+
 // Token attempts to a fetch a token. The user will be required to open a URL
 // in their browser and authenticate to the upstream IdP.
 func (s *LocalOIDCTokenSource) Token(ctx context.Context) (*oidc.Token, error) {

--- a/clitoken/opener.go
+++ b/clitoken/opener.go
@@ -37,6 +37,7 @@ type CommandOpener struct {
 }
 
 func (o *CommandOpener) Open(ctx context.Context, url string) error {
+	_, _ = fmt.Fprintf(os.Stderr, "Opening %s, please return here when authentication complete.", url)
 	cmd := exec.CommandContext(ctx, o.CommandName, url)
 	cmd.Stdin = os.Stdin
 	cmd.Stderr = os.Stderr
@@ -48,6 +49,6 @@ func (o *CommandOpener) Open(ctx context.Context, url string) error {
 type EchoOpener struct{}
 
 func (o *EchoOpener) Open(ctx context.Context, url string) error {
-	_, err := fmt.Printf("To continue, open this URL in a browser: %s\n", url)
+	_, err := fmt.Fprintf(os.Stderr, "To continue, open this URL in a browser: %s\n", url)
 	return err
 }

--- a/clitoken/opener.go
+++ b/clitoken/opener.go
@@ -37,7 +37,7 @@ type CommandOpener struct {
 }
 
 func (o *CommandOpener) Open(ctx context.Context, url string) error {
-	_, _ = fmt.Fprintf(os.Stderr, "Opening %s, please return here when authentication complete.", url)
+	_, _ = fmt.Fprintf(os.Stderr, "Opening %s, please return here when authentication complete.\n", url)
 	cmd := exec.CommandContext(ctx, o.CommandName, url)
 	cmd.Stdin = os.Stdin
 	cmd.Stderr = os.Stderr

--- a/clitoken/opener.go
+++ b/clitoken/opener.go
@@ -37,7 +37,6 @@ type CommandOpener struct {
 }
 
 func (o *CommandOpener) Open(ctx context.Context, url string) error {
-	_, _ = fmt.Fprintf(os.Stderr, "Opening %s, please return here when authentication complete.\n", url)
 	cmd := exec.CommandContext(ctx, o.CommandName, url)
 	cmd.Stdin = os.Stdin
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
Add a way to set a custom opener on a CLI token source, for further experimentation with this, e.g if we want to add a confirmation prompt or give the user more feedback about what is happening.

Also make the `EchoOpener` use stderr for it's message, when this is invoked inside other processes (aws-vault, kubectl) stdout usually contains machine parseable output.