### PR TITLE
Add token refresh grace period

### DIFF
--- a/client.go
+++ b/client.go
@@ -15,7 +15,8 @@ import (
 
 const (
 	// ScopeOfflineAccess requests a refresh token
-	ScopeOfflineAccess = "offline_access"
+	ScopeOfflineAccess         = "offline_access"
+	TokenExpirationGracePeriod = time.Duration(30 * time.Second)
 )
 
 type KeySource interface {
@@ -157,6 +158,11 @@ func (t *Token) Valid() bool {
 	// TODO - nbf claim?
 	return t.Claims.Expiry.Time().After(time.Now()) &&
 		t.IDToken != ""
+}
+
+func (t *Token) WithinGracePeriod() bool {
+	gracePeriodStart := t.Claims.Expiry.Time().Add(-TokenExpirationGracePeriod)
+	return gracePeriodStart.Before(time.Now()) && t.Valid()
 }
 
 // Type of the token

--- a/client.go
+++ b/client.go
@@ -15,8 +15,7 @@ import (
 
 const (
 	// ScopeOfflineAccess requests a refresh token
-	ScopeOfflineAccess         = "offline_access"
-	TokenExpirationGracePeriod = time.Duration(30 * time.Second)
+	ScopeOfflineAccess = "offline_access"
 )
 
 type KeySource interface {
@@ -158,11 +157,6 @@ func (t *Token) Valid() bool {
 	// TODO - nbf claim?
 	return t.Claims.Expiry.Time().After(time.Now()) &&
 		t.IDToken != ""
-}
-
-func (t *Token) WithinGracePeriod() bool {
-	gracePeriodStart := t.Claims.Expiry.Time().Add(-TokenExpirationGracePeriod)
-	return gracePeriodStart.Before(time.Now()) && t.Valid()
 }
 
 // Type of the token

--- a/tokencache/cache_token_source.go
+++ b/tokencache/cache_token_source.go
@@ -92,7 +92,7 @@ func (c *cachingTokenSource) Token(ctx context.Context) (*oidc.Token, error) {
 	}
 
 	var newToken *oidc.Token
-	if token != nil && token.Valid() && !c.WithinGracePeriod(token) {
+	if token != nil && token.Valid() && TokenWithinGracePeriod(token) {
 		return token, nil
 	} else if token != nil && token.RefreshToken != "" {
 		// we have an expired token, try and refresh if we can.
@@ -120,7 +120,7 @@ func (c *cachingTokenSource) Token(ctx context.Context) (*oidc.Token, error) {
 	return newToken, nil
 }
 
-func (c *cachingTokenSource) WithinGracePeriod(token *oidc.Token) bool {
+func TokenWithinGracePeriod(token *oidc.Token) bool {
 	gracePeriodStart := token.Claims.Expiry.Time().Add(-TokenExpirationGracePeriod)
 	return gracePeriodStart.Before(time.Now()) && token.Valid()
 }

--- a/tokencache/cache_token_source.go
+++ b/tokencache/cache_token_source.go
@@ -92,7 +92,7 @@ func (c *cachingTokenSource) Token(ctx context.Context) (*oidc.Token, error) {
 	}
 
 	var newToken *oidc.Token
-	if token != nil && token.Valid() && !TokenWithinGracePeriod(token) {
+	if token != nil && token.Valid() && !tokenWithinGracePeriod(token) {
 		return token, nil
 	} else if token != nil && token.RefreshToken != "" {
 		// we have an expired token, try and refresh if we can.
@@ -120,7 +120,7 @@ func (c *cachingTokenSource) Token(ctx context.Context) (*oidc.Token, error) {
 	return newToken, nil
 }
 
-func TokenWithinGracePeriod(token *oidc.Token) bool {
+func tokenWithinGracePeriod(token *oidc.Token) bool {
 	gracePeriodStart := token.Claims.Expiry.Time().Add(-TokenExpirationGracePeriod)
 	return gracePeriodStart.Before(time.Now()) && token.Valid()
 }

--- a/tokencache/cache_token_source.go
+++ b/tokencache/cache_token_source.go
@@ -92,7 +92,7 @@ func (c *cachingTokenSource) Token(ctx context.Context) (*oidc.Token, error) {
 	}
 
 	var newToken *oidc.Token
-	if token != nil && token.Valid() && TokenWithinGracePeriod(token) {
+	if token != nil && token.Valid() && !TokenWithinGracePeriod(token) {
 		return token, nil
 	} else if token != nil && token.RefreshToken != "" {
 		// we have an expired token, try and refresh if we can.

--- a/tokencache/cache_token_source.go
+++ b/tokencache/cache_token_source.go
@@ -87,7 +87,7 @@ func (c *cachingTokenSource) Token(ctx context.Context) (*oidc.Token, error) {
 	}
 
 	var newToken *oidc.Token
-	if token != nil && token.Valid() {
+	if token != nil && token.Valid() && !token.WithinGracePeriod() {
 		return token, nil
 	} else if token != nil && token.RefreshToken != "" {
 		// we have an expired token, try and refresh if we can.

--- a/tokencache/cache_token_source.go
+++ b/tokencache/cache_token_source.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	TokenExpirationGracePeriod = time.Duration(30 * time.Second)
+	tokenExpirationGracePeriod = time.Duration(30 * time.Second)
 )
 
 type cachingTokenSource struct {
@@ -121,6 +121,6 @@ func (c *cachingTokenSource) Token(ctx context.Context) (*oidc.Token, error) {
 }
 
 func tokenWithinGracePeriod(token *oidc.Token) bool {
-	gracePeriodStart := token.Claims.Expiry.Time().Add(-TokenExpirationGracePeriod)
+	gracePeriodStart := token.Claims.Expiry.Time().Add(-tokenExpirationGracePeriod)
 	return gracePeriodStart.Before(time.Now()) && token.Valid()
 }

--- a/tokencache/cache_token_source.go
+++ b/tokencache/cache_token_source.go
@@ -3,8 +3,13 @@ package tokencache
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/pardot/oidc"
+)
+
+const (
+	TokenExpirationGracePeriod = time.Duration(30 * time.Second)
 )
 
 type cachingTokenSource struct {
@@ -87,7 +92,7 @@ func (c *cachingTokenSource) Token(ctx context.Context) (*oidc.Token, error) {
 	}
 
 	var newToken *oidc.Token
-	if token != nil && token.Valid() && !token.WithinGracePeriod() {
+	if token != nil && token.Valid() && !c.WithinGracePeriod(token) {
 		return token, nil
 	} else if token != nil && token.RefreshToken != "" {
 		// we have an expired token, try and refresh if we can.
@@ -113,4 +118,9 @@ func (c *cachingTokenSource) Token(ctx context.Context) (*oidc.Token, error) {
 	}
 
 	return newToken, nil
+}
+
+func (c *cachingTokenSource) WithinGracePeriod(token *oidc.Token) bool {
+	gracePeriodStart := token.Claims.Expiry.Time().Add(-TokenExpirationGracePeriod)
+	return gracePeriodStart.Before(time.Now()) && token.Valid()
 }


### PR DESCRIPTION
This change adds a 30 second grace period to token refreshes so that the token currently cache can be renewed up to 30 seconds before it expires. This minimizes the scenario where a cached token is used and immediately expires. 